### PR TITLE
Fix typo

### DIFF
--- a/generators/app/index.es6.js
+++ b/generators/app/index.es6.js
@@ -195,7 +195,7 @@ class Starterkit extends Base {
 			default: this.appname
 		}, {
 			name: 'description',
-			message: 'Enter a the description for your project',
+			message: 'Enter a description for your project',
 			validate(value) {
 				if (value !== '') {
 					return true;


### PR DESCRIPTION
Correct small typo in one of the messages of the generator
- [x] All tests passed.
